### PR TITLE
Handle paths with spaces

### DIFF
--- a/src/rxjs-5-to-6-migrate.ts
+++ b/src/rxjs-5-to-6-migrate.ts
@@ -9,9 +9,9 @@ if (!argv.p) {
 }
 
 const command =
-  join(__dirname, 'node_modules', '.bin', 'tslint') +
+  join('"' + __dirname + '"', 'node_modules', '.bin', 'tslint') +
   ' -c ' +
-  join(__dirname, 'rxjs-5-to-6-migrate.json') +
+  join('"' + __dirname + '"', 'rxjs-5-to-6-migrate.json') +
   ' -p ' +
   argv.p +
   ' --fix';


### PR DESCRIPTION
Quoting `__dirname` in case it contains a space.  Opting to concatenate the quotes instead of making them params for `path` soley for a cleaner looking command: `%> "/my path"/node_modules/...` instead of `%> "/my path/"/node_modules/...`